### PR TITLE
Fix module imports under Python 3

### DIFF
--- a/envplus/__init__.py
+++ b/envplus/__init__.py
@@ -1,6 +1,8 @@
+from __future__ import absolute_import
+
 import env
-import pathfile
-import helpers
+import envplus.pathfile
+import envplus.helpers
 
 VERSION_TUPLE = (0, 0, 0)
 VERSION = ".".join(map(str, VERSION_TUPLE))

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if sys.version_info <= (2, 6):
 
 setup(
     name="envplus",
-    version="0.0.0",
+    version="0.0.1",
     description="Combine your virtualenvs.",
     long_description="",
     classifiers=[
@@ -32,7 +32,8 @@ setup(
     include_package_data=False,
     zip_safe=False,
     install_requires=[
-        "virtualenvwrapper"
+        "virtualenvwrapper",
+        "env"
     ] + py26_dependency,
     tests_require=[],
     test_suite="test",


### PR DESCRIPTION
This PR fixes the envplus module imports failing under Python 3. It also adds the env package requirement which previously had to be installed manually.

I've opened a PR over in the [env repo](https://github.com/kennethreitz/env/pull/6) that's also required for Python3 compatibility.

I love this package, it's saved me many headaches 😄 